### PR TITLE
Fix metadata mapping to accession

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -26,7 +26,8 @@ def fetch_metadata(ids, api_key):
             for k, v in zip(subtype, subname):
                 meta[k] = v
             meta["release_date"] = info.get("createdate", "")
-            metadata[uid] = meta
+            acc = info.get("accessionversion", uid)
+            metadata[acc] = meta
     return metadata
 
 def fetch_fasta(ids, api_key):


### PR DESCRIPTION
## Summary
- fix metadata lookup by using accessionversion as key

## Testing
- `pip install -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6844b526244483289170be58c87d4bf5