### PR TITLE
Add feature extraction for all sequences and zipped outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,11 +17,15 @@ streamlit run streamlit_app.py
 ```
 
 Provide your NCBI API key and a taxon name (e.g. `Potyvirus`). The app will
-produce three downloadable files:
+produce several downloadable files which are also bundled into a single zip
+archive:
 
 - `<Taxon_Name>.fasta` – all sequences with isolate, host, country,
   collection date and release date in the headers. Metadata is gathered from
   both `esummary` and GenBank records to ensure these fields are populated when
   available.
+- `<Taxon_Name>_sequences_features.txt` – features for every sequence returned
+  for the taxon.
 - `<Taxon_Name>_refseq.fasta` – the RefSeq sequence for the taxon (if available).
 - `<Taxon_Name>_features.txt` – list of features (UTRs, CDS, mat_peptides, etc.) from the RefSeq record.
+- `<Taxon_Name>_outputs.zip` – archive containing all of the above files for easy download.


### PR DESCRIPTION
## Summary
- add ability to fetch features for all sequences
- store them in `<taxon>_sequences_features.txt`
- bundle all result files into a zip for one-click download
- document new behaviour in README

## Testing
- `python -m py_compile streamlit_app.py`

------
https://chatgpt.com/codex/tasks/task_e_6845e09d7e60832889511272c61b008a