### PR TITLE
Handle missing MAFFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ This repository contains a small command line tool that queries NCBI for virus s
 pip install -r requirements.txt
 ```
 
+The optional partitioning and alignment step requires the external
+[MAFFT](https://mafft.cbrc.jp/alignment/software/) executable to be
+installed and available on your `PATH`.
+
 ## Usage
 
 Run the script:

--- a/phylogen.py
+++ b/phylogen.py
@@ -6,6 +6,7 @@ import os
 import zipfile
 import tempfile
 import subprocess
+import shutil
 
 def fetch_ids(taxon, api_key):
     search_term = f"\"{taxon}\"[Organism]"
@@ -152,6 +153,10 @@ def _run_mafft(records):
     """Align a list of SeqRecord objects with MAFFT L-INS-i."""
     if not records:
         return []
+    if shutil.which("mafft") is None:
+        raise FileNotFoundError(
+            "MAFFT executable not found. Please install MAFFT and ensure it is in your PATH."
+        )
     with tempfile.TemporaryDirectory() as tmpdir:
         in_f = os.path.join(tmpdir, "in.fasta")
         SeqIO.write(records, in_f, "fasta")


### PR DESCRIPTION
## Summary
- check for the MAFFT executable before attempting to align sequences
- document MAFFT requirement in README

## Testing
- `python -m py_compile phylogen.py`

------
https://chatgpt.com/codex/tasks/task_e_68473c5ce6308328b3fec6292c4ad64b