### PR TITLE
Fix Windows invocation of MAFFT

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,11 @@ This repository contains a small command line tool that queries NCBI for virus s
 pip install -r requirements.txt
 ```
 
+The optional partitioning and alignment step uses Biopython's
+`MafftCommandline` wrapper and requires the external
+[MAFFT](https://mafft.cbrc.jp/alignment/software/) executable to be
+installed and available on your `PATH`.
+
 ## Usage
 
 Run the script:


### PR DESCRIPTION
## Summary
- check for MAFFT path then handle .bat/.cmd wrappers on Windows
- swap subprocess call for Biopython's `MafftCommandline`
- mention Biopython wrapper in README

## Testing
- `python -m py_compile phylogen.py`


------
https://chatgpt.com/codex/tasks/task_e_68473c5ce6308328b3fec6292c4ad64b