### PR TITLE
Align CDS sequences

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,7 @@ It produces several files which are also bundled into a single zip archive:
 - `<Taxon_Name>_refseq.fasta` – the RefSeq sequence for the taxon (if available).
 - `<Taxon_Name>_features.txt` – list of features (UTRs, CDS, mat_peptides, etc.) from the RefSeq record.
 - `<Taxon_Name>_outputs.zip` – archive containing all of the above files for easy download.
+
+Optionally, the script can align all coding sequences (CDSs) using MAFFT. If selected,
+an additional file `<Taxon_Name>_cds_alignment.fasta` containing the translated,
+aligned and back-translated CDSs will be produced.


### PR DESCRIPTION
## Summary
- extract all CDS features instead of 5'UTR/CDS/3'UTR
- translate, align and back-translate each CDS and concatenate them
- add interactive option to produce a CDS alignment
- document CDS alignment output in the README

## Testing
- `python -m py_compile phylogen.py`


------
https://chatgpt.com/codex/tasks/task_e_6849830ddedc832887ffe4248daf6d1b