### PR TITLE
Add per-CDS alignment with refseq proteins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ It produces several files:
 - `<Taxon_Name>_refseq.fasta` – the RefSeq sequence for the taxon (if available).
 - `<Taxon_Name>_refseq_features.txt` – list of features (UTRs, CDS, mat_peptides, etc.) from the RefSeq record.
 
-Optionally, the script can align all coding sequences (CDSs) using MAFFT. If selected,
-an additional file `<Taxon_Name>_cds_alignment.fasta` containing the translated,
-aligned and back-translated CDSs will be produced.
+Optionally, the script can align all coding sequences (CDSs). Each CDS is aligned
+individually with the corresponding RefSeq protein placed at the top of the
+alignment. The resulting file `<Taxon_Name>_cds_alignment.fasta` contains the
+nucleotide alignments for every CDS with gaps added when a sequence lacks a
+particular CDS.

--- a/phylogen.py
+++ b/phylogen.py
@@ -102,25 +102,40 @@ def fetch_all_features(ids, api_key):
     return "\n".join(lines)
 
 def fetch_refseq(taxon, api_key):
+    """Return RefSeq record information including proteins."""
+
     term = f"\"{taxon}\"[Organism] AND srcdb_refseq[PROP]"
     handle = Entrez.esearch(db="nuccore", term=term, retmax=1, api_key=api_key)
     record = Entrez.read(handle)
     handle.close()
     ids = record.get("IdList", [])
     if not ids:
-        return None, None, None
+        return None, None, None, []
+
     refseq_id = ids[0]
-    handle = Entrez.efetch(db="nuccore", id=refseq_id, rettype="fasta", retmode="text", api_key=api_key)
-    fasta = handle.read()
-    handle.close()
-    handle = Entrez.efetch(db="nuccore", id=refseq_id, rettype="gb", retmode="text", api_key=api_key)
+
+    handle = Entrez.efetch(
+        db="nuccore", id=refseq_id, rettype="gb", retmode="text", api_key=api_key
+    )
     gb = handle.read()
     handle.close()
+
+    fasta = None
     features = []
+    proteins = []
     for record in SeqIO.parse(io.StringIO(gb), "genbank"):
+        fasta = f">{record.id}\n{record.seq}\n"
         for feat in record.features:
             features.append(f"{feat.type}: {feat.location}")
-    return refseq_id, fasta, "\n".join(features)
+            if feat.type == "CDS":
+                prot_seq = feat.qualifiers.get("translation", [""])[0]
+                prot_id = feat.qualifiers.get("protein_id", [""])[0]
+                gene = feat.qualifiers.get("gene", [""])[0]
+                product = feat.qualifiers.get("product", [""])[0]
+                label = gene or product or prot_id or f"protein_{len(proteins)+1}"
+                proteins.append(SeqRecord(Seq(prot_seq), id=label))
+
+    return refseq_id, fasta, "\n".join(features), proteins
 
 
 def _extract_cds_features(record):
@@ -186,9 +201,55 @@ def _align_translate_back(cds_records):
     return aligned_nt
 
 
-def align_cds(fasta_file, ids, api_key):
-    """Retrieve all CDS regions, align each and concatenate the results."""
-    records = list(SeqIO.parse(fasta_file, "fasta"))
+def _align_translate_back_with_ref(cds_records, ref_protein=None):
+    """Translate CDSs, include an optional reference protein and align."""
+
+    aa_records = []
+    codons = {}
+    ref_id = None
+
+    if ref_protein is not None:
+        ref_id = ref_protein.id
+        aa_records.append(ref_protein)
+
+    for rec in cds_records:
+        seq = rec.seq
+        codon_start = int(rec.annotations.get("codon_start", 1))
+        if codon_start > 1:
+            seq = seq[codon_start - 1:]
+        if len(seq) % 3:
+            pad = 3 - len(seq) % 3
+            seq = seq + Seq("N" * pad)
+        codon_list = [str(seq[i:i + 3]) for i in range(0, len(seq), 3)]
+        codons[rec.id] = codon_list
+        aa_records.append(SeqRecord(seq.translate(to_stop=False), id=rec.id))
+
+    aligned_aa = _run_mafft(aa_records)
+
+    aligned_nt = {}
+    ref_aligned = None
+    for rec in aligned_aa:
+        if ref_id is not None and rec.id == ref_id:
+            ref_aligned = rec.seq
+            continue
+        codon_list = codons[rec.id]
+        idx = 0
+        nt_frag = []
+        for aa in str(rec.seq):
+            if aa == "-":
+                nt_frag.append("---")
+            else:
+                nt_frag.append(codon_list[idx])
+                idx += 1
+        aligned_nt[rec.id] = SeqRecord(Seq("".join(nt_frag)), id=rec.id)
+
+    return aligned_nt, ref_aligned
+
+
+def align_cds(fasta_file, ids, api_key, ref_proteins=None):
+    """Retrieve CDS regions, align each separately and include RefSeq proteins."""
+
+    records = [rec for rec in SeqIO.parse(fasta_file, "fasta") if rec.id in ids]
     order = [rec.id for rec in records]
 
     cds_parts = {}
@@ -201,34 +262,48 @@ def align_cds(fasta_file, ids, api_key):
         handle.close()
 
     max_parts = max(len(v) for v in cds_parts.values()) if cds_parts else 0
-    aligned_by_part = {seq_id: [] for seq_id in order}
+    n_parts = max(max_parts, len(ref_proteins) if ref_proteins else 0)
 
-    for idx in range(max_parts):
+    final_records = []
+
+    for idx in range(n_parts):
         cds_recs = []
         for sid in order:
             if idx < len(cds_parts.get(sid, [])):
                 seq, codon_start = cds_parts[sid][idx]
                 cds_recs.append(
-                    SeqRecord(
-                        seq,
-                        id=sid,
-                        annotations={"codon_start": codon_start},
-                    )
+                    SeqRecord(seq, id=sid, annotations={"codon_start": codon_start})
                 )
-        if not cds_recs:
-            continue
-        aligned = _align_translate_back(cds_recs)
-        part_len = len(next(iter(aligned.values())).seq)
-        for sid in order:
-            if sid in aligned:
-                aligned_by_part[sid].append(aligned[sid].seq)
-            else:
-                aligned_by_part[sid].append(Seq("-" * part_len))
 
-    final_records = []
-    for sid in order:
-        seq = Seq("".join(str(s) for s in aligned_by_part[sid]))
-        final_records.append(SeqRecord(seq, id=sid))
+        ref_rec = None
+        if ref_proteins and idx < len(ref_proteins):
+            ref_rec = ref_proteins[idx]
+
+        if not cds_recs and ref_rec is None:
+            continue
+
+        aligned, ref_aln = _align_translate_back_with_ref(cds_recs, ref_rec)
+
+        part_len = None
+        if ref_aln is not None:
+            part_len = len(ref_aln) * 3
+        elif aligned:
+            part_len = len(next(iter(aligned.values())).seq)
+
+        if ref_aln is not None:
+            final_records.append(
+                SeqRecord(ref_aln, id=f"RefSeq|{ref_rec.id}")
+            )
+
+        for sid in order:
+            label = f"{sid}|CDS{idx + 1}"
+            if ref_rec is not None:
+                label = f"{sid}|{ref_rec.id}"
+            if sid in aligned:
+                final_records.append(SeqRecord(aligned[sid].seq, id=label))
+            else:
+                if part_len is not None:
+                    final_records.append(SeqRecord(Seq("-" * part_len), id=label))
 
     output = io.StringIO()
     SeqIO.write(final_records, output, "fasta")
@@ -282,7 +357,7 @@ def main():
         f.write(features_data)
     print(f"Sequence features written to {seq_feat_file}")
 
-    ref_id, ref_fasta, features = fetch_refseq(taxon, api_key)
+    ref_id, ref_fasta, features, ref_proteins = fetch_refseq(taxon, api_key)
     if ref_id:
         ref_file = output_dir / f"{base}_refseq.fasta"
         with open(ref_file, "w") as f:
@@ -298,7 +373,8 @@ def main():
 
     choice = input("Align CDS sequences only? [y/N]: ").strip().lower()
     if choice == "y":
-        aligned = align_cds(fasta_file, ids, api_key)
+        ids_no_ref = [i for i in ids if i != ref_id]
+        aligned = align_cds(fasta_file, ids_no_ref, api_key, ref_proteins)
         align_file = output_dir / f"{base}_cds_alignment.fasta"
         with open(align_file, "w") as af:
             af.write(aligned)


### PR DESCRIPTION
## Summary
- return refseq proteins from `fetch_refseq`
- align each CDS separately and include refseq proteins
- skip refseq sequence from alignment
- document the new behaviour in README

## Testing
- `pip install -r requirements.txt`
- `python -m py_compile phylogen.py`


------
https://chatgpt.com/codex/tasks/task_e_684ae5ca645c8328bd675fefd6aa24f3