### PR TITLE
Add two-step mat_peptide alignment

### DIFF
--- a/phylogen.py
+++ b/phylogen.py
@@ -120,7 +120,7 @@ def fetch_all_features(ids, api_key):
     return "\n".join(lines)
 
 def fetch_refseq(taxon, api_key):
-    """Return RefSeq record information including proteins."""
+    """Return RefSeq record information including proteins and mat_peptide positions."""
 
     term = f"\"{taxon}\"[Organism] AND srcdb_refseq[PROP]"
     handle = Entrez.esearch(db="nuccore", term=term, retmax=1, api_key=api_key)
@@ -141,6 +141,7 @@ def fetch_refseq(taxon, api_key):
     fasta = None
     features = []
     proteins = []
+    pep_positions = []
     for record in SeqIO.parse(io.StringIO(gb), "genbank"):
         fasta = f">{record.id}\n{record.seq}\n"
         for feat in record.features:
@@ -160,8 +161,16 @@ def fetch_refseq(taxon, api_key):
                 label = gene or product or prot_id or f"protein_{len(proteins)+1}"
                 label = label.replace(" ", "_")
                 proteins.append(SeqRecord(prot_seq, id=label))
+                pep_positions.append(
+                    {
+                        "label": label,
+                        "start": int(feat.location.start),
+                        "end": int(feat.location.end),
+                        "codon_start": codon_start,
+                    }
+                )
 
-    return refseq_id, fasta, "\n".join(features), proteins
+    return refseq_id, fasta, "\n".join(features), proteins, pep_positions
 
 
 def _extract_mat_peptide_features(record):
@@ -240,6 +249,90 @@ def _align_translate_back_with_ref(cds_records, ref_protein=None):
         aligned_nt[rec.id] = SeqRecord(Seq("".join(nt_frag)), id=rec.id)
 
     return aligned_nt, ref_aligned
+
+
+def _choose_frame_no_stop(seq):
+    """Return codon_start (1-based) for frame without stop codons."""
+    s = str(seq).replace("-", "")
+    for frame in range(3):
+        sub = s[frame:]
+        sub = sub[: len(sub) // 3 * 3]
+        if not sub:
+            return frame + 1
+        aa = Seq(sub).translate(to_stop=False)
+        if "*" not in str(aa):
+            return frame + 1
+    return 1
+
+
+def align_mat_peptides_two_step(
+    fasta_file, ids, api_key, ref_id, ref_pep_positions, ref_proteins=None
+):
+    """Two-step alignment of mat_peptides based on RefSeq coordinates."""
+
+    rec_dict = {
+        rec.id: rec
+        for rec in SeqIO.parse(fasta_file, "fasta")
+        if rec.id in ids or rec.id == ref_id
+    }
+    order = [i for i in ids if i != ref_id]
+
+    # first alignment of full sequences including refseq
+    full_aln = _run_mafft([rec_dict[ref_id]] + [rec_dict[i] for i in order])
+    aln_dict = {r.id: r.seq for r in full_aln}
+    ref_aln = aln_dict[ref_id]
+
+    # map reference positions to alignment columns
+    pos_to_col = {}
+    pos = 0
+    for idx, nt in enumerate(str(ref_aln)):
+        if nt != "-":
+            pos_to_col[pos] = idx
+            pos += 1
+
+    concatenated = {sid: [] for sid in order}
+
+    for idx, feat in enumerate(ref_pep_positions):
+        start = feat["start"]
+        end = feat["end"]
+        start_col = pos_to_col.get(start)
+        end_col = pos_to_col.get(end - 1)
+        if start_col is None or end_col is None:
+            continue
+        end_col += 1
+
+        pep_records = []
+        for sid in order:
+            sub = aln_dict[sid][start_col:end_col]
+            raw = Seq(str(sub).replace("-", ""))
+            frame = _choose_frame_no_stop(raw)
+            pep_records.append(
+                SeqRecord(raw, id=sid, annotations={"codon_start": frame})
+            )
+
+        ref_rec = None
+        if ref_proteins and idx < len(ref_proteins):
+            ref_rec = ref_proteins[idx]
+
+        aligned_nt, ref_aln_seq = _align_translate_back_with_ref(pep_records, ref_rec)
+
+        part_len = 0
+        if ref_aln_seq is not None:
+            part_len = len(ref_aln_seq) * 3
+        elif aligned_nt:
+            part_len = len(next(iter(aligned_nt.values())).seq)
+
+        for sid in order:
+            if sid in aligned_nt:
+                concatenated[sid].append(str(aligned_nt[sid].seq))
+            else:
+                concatenated[sid].append("-" * part_len)
+
+    final_records = [SeqRecord(Seq("".join(v)), id=k) for k, v in concatenated.items()]
+
+    output = io.StringIO()
+    SeqIO.write(final_records, output, "fasta")
+    return output.getvalue()
 
 
 def align_mat_peptides(fasta_file, ids, api_key, ref_proteins=None):
@@ -353,7 +446,7 @@ def main():
         f.write(features_data)
     print(f"Sequence features written to {seq_feat_file}")
 
-    ref_id, ref_fasta, features, ref_proteins = fetch_refseq(taxon, api_key)
+    ref_id, ref_fasta, features, ref_proteins, pep_positions = fetch_refseq(taxon, api_key)
     if ref_id:
         ref_file = output_dir / f"{base}_refseq.fasta"
         with open(ref_file, "w") as f:
@@ -370,7 +463,14 @@ def main():
     choice = input("Align mat_peptide sequences only? [y/N]: ").strip().lower()
     if choice == "y":
         ids_no_ref = [i for i in ids if i != ref_id]
-        aligned = align_mat_peptides(fasta_file, ids_no_ref, api_key, ref_proteins)
+        aligned = align_mat_peptides_two_step(
+            fasta_file,
+            ids_no_ref,
+            api_key,
+            ref_id,
+            pep_positions,
+            ref_proteins,
+        )
         align_file = output_dir / f"{base}_mat_peptide_alignment.fasta"
         with open(align_file, "w") as af:
             af.write(aligned)


### PR DESCRIPTION
## Summary
- extend `fetch_refseq` to also return mat_peptide coordinates
- add helper to pick translation frame without stop codons
- implement `align_mat_peptides_two_step` to perform full-genome alignment, slice
  by mat_peptide coordinates and re-align peptides
- call the new alignment routine from `main`

## Testing
- `python -m py_compile phylogen.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68552e699b4c8328a58243d70962c16a