### PR TITLE
Fix merge conflicts for per-peptide alignment outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,3 +38,5 @@ Each peptide is aligned individually with the corresponding RefSeq protein place
 at the top of the alignment. The resulting file `<Taxon_Name>_mat_peptide_alignment.fasta`
 contains the nucleotide alignments for every peptide with gaps added when a sequence
 lacks a particular peptide.
+Additionally, separate alignment files `<Taxon_Name>_<Peptide_Label>_alignment.fasta`
+are produced for each RefSeq mat-peptide.


### PR DESCRIPTION
## Summary
- merge latest `main` and resolve conflicts
- restore per-peptide outputs when aligning mat peptides

## Testing
- `python -m py_compile phylogen.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68552e699b4c8328a58243d70962c16a